### PR TITLE
Google OAuth Button

### DIFF
--- a/actions/auth/signin.ts
+++ b/actions/auth/signin.ts
@@ -1,4 +1,4 @@
-import { requestSignin } from '../../api';
+import { requestSignin, loginWithGoogle } from '../../api';
 import { ActionCreator, NetworkAction, Dispatch, ActionType } from '..';
 import { ProgressStatus } from '../../data-types';
 
@@ -40,6 +40,17 @@ export const signinUser = (email: string, password: string) => async (dispatch: 
   try {
     const res = await requestSignin(email, password);
     return dispatch(receiveSigninResponse(res));
+  } catch (err) {
+    return dispatch(receiveSigninError(err));
+  }
+};
+
+export const googleOAuthUser = () => async (dispatch: Dispatch) => {
+  dispatch(startSigninRequest());
+
+  try {
+    await loginWithGoogle();
+    return dispatch(receiveSigninResponse());
   } catch (err) {
     return dispatch(receiveSigninError(err));
   }

--- a/api/auth.ts
+++ b/api/auth.ts
@@ -51,3 +51,13 @@ export const requestUpdatePassword = (newPassword: string) => {
     ? currentUser.updatePassword(newPassword)
     : Promise.reject(new Error('User does not exist.'));
 };
+
+const googleProvider = new firebase.auth.GoogleAuthProvider();
+
+export const loginWithGoogle = () =>
+  firebase
+    .auth()
+    .signInWithPopup(googleProvider)
+    .then(result => {
+      console.log(result);
+    });

--- a/components/SocialButton/GoogleButton.tsx
+++ b/components/SocialButton/GoogleButton.tsx
@@ -1,12 +1,29 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { GoogleLogo } from '../../util/svg';
 
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: 40, // does not recognize dp
+    paddingHorizontal: 8,
+    borderBottomColor: 'black',
+  },
+  logo: {
+    marginRight: 24,
+  },
+  text: {
+    color: 'rgba(0,0,0,0.54)',
+  },
+});
+
 const GoogleButton = () => (
-  <View>
-    <GoogleLogo />
-    <Text>Sign in with Google</Text>
-  </View>
+  <TouchableOpacity style={styles.container}>
+    <GoogleLogo style={styles.logo} />
+    <Text style={styles.text}>Sign in with Google</Text>
+  </TouchableOpacity>
 );
 
 export default GoogleButton;

--- a/components/SocialButton/GoogleButton.tsx
+++ b/components/SocialButton/GoogleButton.tsx
@@ -1,30 +1,28 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View } from 'react-native-web';
+
 import { GoogleLogo } from '../../util/svg';
-import { Colors } from '../../styles';
+import { Margins, Shadows } from '../../styles';
 
 const styles = StyleSheet.create({
-  background: {
-    backgroundColor: '#EEEEEE',
-  },
   container: {
+    width: 'fit-content',
+    alignSelf: 'center',
     justifyContent: 'center',
     alignItems: 'center',
-    height: 40, // does not recognize dp
-    paddingHorizontal: 8,
-    shadowOffset: {
-      height: 2,
-      width: 0,
-    },
-    borderRadius: 2,
-    shadowRadius: 5,
-    shadowOpacity: 0.5,
-    shadowColor: Colors.SHADOW.toString(),
+    marginTop: Margins.MAX_Y,
+    borderRadius: 5,
+    backgroundColor: '#EEEEEE',
+    ...Shadows.FORM_CONTAINER,
   },
   button: {
+    height: 40, // does not recognize dp
+    paddingHorizontal: 8,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
+    backgroundColor: 'white',
   },
   logo: {
     marginRight: 24,
@@ -36,6 +34,8 @@ const styles = StyleSheet.create({
   },
 });
 
+// TODO: This changes the opacity of Logo and Text too, really I just want the background to transition color
+// May need to switch to animated for this, but this is low priority in terms of functionality
 const GoogleButton = () => (
   <View style={styles.container}>
     <TouchableOpacity style={styles.button}>

--- a/components/SocialButton/GoogleButton.tsx
+++ b/components/SocialButton/GoogleButton.tsx
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginTop: Margins.MAX_Y,
     borderRadius: 5,
-    backgroundColor: '#EEEEEE',
+    backgroundColor: '#EEEEEE', // From Google's Sketch
     ...Shadows.FORM_CONTAINER,
   },
   button: {
@@ -29,16 +29,20 @@ const styles = StyleSheet.create({
   },
   text: {
     // TODO: Move this to Colors
-    color: 'rgba(0,0,0,0.54)',
-    fontFamily: "'Roboto', sans-serif;",
+    color: 'rgba(0,0,0,0.54)', // From Google's Sketch
+    fontFamily: "'Roboto', sans-serif;", // From Google's brandline
   },
 });
 
 // TODO: This changes the opacity of Logo and Text too, really I just want the background to transition color
 // May need to switch to animated for this, but this is low priority in terms of functionality
-const GoogleButton = () => (
+interface GoogleButtonProps {
+  onPress: () => void;
+}
+
+const GoogleButton: React.FC<GoogleButtonProps> = ({ onPress }: GoogleButtonProps) => (
   <View style={styles.container}>
-    <TouchableOpacity style={styles.button}>
+    <TouchableOpacity style={styles.button} onPress={onPress}>
       <GoogleLogo style={styles.logo} />
       <Text style={styles.text}>Sign in with Google</Text>
     </TouchableOpacity>

--- a/components/SocialButton/GoogleButton.tsx
+++ b/components/SocialButton/GoogleButton.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { GoogleLogo } from '../../util/svg';
+
+const GoogleButton = () => (
+  <View>
+    <GoogleLogo />
+    <Text>Sign in with Google</Text>
+  </View>
+);
+
+export default GoogleButton;

--- a/components/SocialButton/GoogleButton.tsx
+++ b/components/SocialButton/GoogleButton.tsx
@@ -3,34 +3,34 @@ import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { View } from 'react-native-web';
 
 import { GoogleLogo } from '../../util/svg';
-import { Margins, Shadows } from '../../styles';
+import { Margins, Shadows, Buttons, Paddings } from '../../styles';
 
 const styles = StyleSheet.create({
   container: {
-    width: 'fit-content',
-    alignSelf: 'center',
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginTop: Margins.MAX_Y,
-    borderRadius: 5,
-    backgroundColor: '#EEEEEE', // From Google's Sketch
+    borderRadius: Buttons.BORDER_RADIUS,
+    marginTop: Margins.Y,
+    minWidth: Buttons.MIN_WIDTH,
     ...Shadows.FORM_CONTAINER,
   },
   button: {
-    height: 40, // does not recognize dp
-    paddingHorizontal: 8,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'white',
+    height: 48,
+    borderRadius: Buttons.BORDER_RADIUS,
+    paddingHorizontal: Paddings.MIN_X,
   },
   logo: {
     marginRight: 24,
+    width: 22,
+    height: 22,
   },
   text: {
     // TODO: Move this to Colors
     color: 'rgba(0,0,0,0.54)', // From Google's Sketch
     fontFamily: "'Roboto', sans-serif;", // From Google's brandline
+    fontSize: Buttons.FONT_SIZE,
   },
 });
 

--- a/components/SocialButton/GoogleButton.tsx
+++ b/components/SocialButton/GoogleButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { View } from 'react-native-web';
-
+import { t } from 'i18n-js';
 import { GoogleLogo } from '../../util/svg';
 import { Margins, Shadows, Buttons, Paddings } from '../../styles';
 
@@ -44,7 +44,7 @@ const GoogleButton: React.FC<GoogleButtonProps> = ({ onPress }: GoogleButtonProp
   <View style={styles.container}>
     <TouchableOpacity style={styles.button} onPress={onPress}>
       <GoogleLogo style={styles.logo} />
-      <Text style={styles.text}>Sign in with Google</Text>
+      <Text style={styles.text}>{t('buttons.signInGoogle')}</Text>
     </TouchableOpacity>
   </View>
 );

--- a/components/SocialButton/GoogleButton.tsx
+++ b/components/SocialButton/GoogleButton.tsx
@@ -1,29 +1,48 @@
 import React from 'react';
-import { Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { GoogleLogo } from '../../util/svg';
+import { Colors } from '../../styles';
 
 const styles = StyleSheet.create({
+  background: {
+    backgroundColor: '#EEEEEE',
+  },
   container: {
-    flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
     height: 40, // does not recognize dp
     paddingHorizontal: 8,
-    borderBottomColor: 'black',
+    shadowOffset: {
+      height: 2,
+      width: 0,
+    },
+    borderRadius: 2,
+    shadowRadius: 5,
+    shadowOpacity: 0.5,
+    shadowColor: Colors.SHADOW.toString(),
+  },
+  button: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   logo: {
     marginRight: 24,
   },
   text: {
+    // TODO: Move this to Colors
     color: 'rgba(0,0,0,0.54)',
+    fontFamily: "'Roboto', sans-serif;",
   },
 });
 
 const GoogleButton = () => (
-  <TouchableOpacity style={styles.container}>
-    <GoogleLogo style={styles.logo} />
-    <Text style={styles.text}>Sign in with Google</Text>
-  </TouchableOpacity>
+  <View style={styles.container}>
+    <TouchableOpacity style={styles.button}>
+      <GoogleLogo style={styles.logo} />
+      <Text style={styles.text}>Sign in with Google</Text>
+    </TouchableOpacity>
+  </View>
 );
 
 export default GoogleButton;

--- a/components/SocialButton/index.ts
+++ b/components/SocialButton/index.ts
@@ -1,0 +1,5 @@
+import GoogleButton from './GoogleButton';
+
+export default {
+  GoogleButton,
+};

--- a/components/SocialButton/index.ts
+++ b/components/SocialButton/index.ts
@@ -1,5 +1,2 @@
-import GoogleButton from './GoogleButton';
-
-export default {
-  GoogleButton,
-};
+// Fixed in TS 3.8.0
+// export * from './GoogleButton';

--- a/components/SocialButton/index.ts
+++ b/components/SocialButton/index.ts
@@ -1,2 +1,0 @@
-// Fixed in TS 3.8.0
-// export * from './GoogleButton';

--- a/components/StaticButton/index.tsx
+++ b/components/StaticButton/index.tsx
@@ -3,20 +3,18 @@ import { StyleSheet, View, TextStyle, TouchableHighlight } from 'react-native';
 import Text from '../Text';
 import { Colors, Buttons, Paddings, Shadows } from '../../styles';
 
-const BORDER_RADIUS = 5;
-
 export const styles = StyleSheet.create({
   container: {
+    borderRadius: Buttons.BORDER_RADIUS,
     minWidth: Buttons.MIN_WIDTH,
-    borderRadius: BORDER_RADIUS,
     ...Shadows.FORM_CONTAINER,
   },
   rectButton: {
     justifyContent: 'center',
     alignItems: 'center',
-    paddingHorizontal: Paddings.MIN_X,
+    borderRadius: Buttons.BORDER_RADIUS,
+    height: Buttons.HEIGHT,
     paddingVertical: Paddings.MIN_Y * 3,
-    borderRadius: BORDER_RADIUS,
   },
 });
 
@@ -36,9 +34,9 @@ export default function StaticButton({
   onPress,
 }: Props) {
   return (
-    <View style={[styles.container, { backgroundColor, shadowColor: backgroundColor }]}>
+    <View style={[styles.container, { shadowColor: backgroundColor }]}>
       <TouchableHighlight
-        style={styles.rectButton}
+        style={[styles.rectButton, { backgroundColor }]}
         activeOpacity={1}
         onPress={onPress}
         disabled={disabled}>

--- a/components/SubmitButton/index.tsx
+++ b/components/SubmitButton/index.tsx
@@ -14,21 +14,19 @@ import { Colors, Buttons, Paddings, Margins, Shadows } from '../../styles';
 
 const TouchableOpacityAnimated = Animated.createAnimatedComponent(TouchableOpacity);
 
-const BORDER_RADIUS = 5;
-
 export const styles = StyleSheet.create({
   container: {
-    ...Shadows.FORM_CONTAINER,
+    borderRadius: Buttons.BORDER_RADIUS,
     marginTop: Margins.MAX_Y,
-    borderRadius: BORDER_RADIUS,
     minWidth: Buttons.MIN_WIDTH,
+    ...Shadows.FORM_CONTAINER,
   },
   rectButton: {
     justifyContent: 'center',
     alignItems: 'center',
+    height: Buttons.HEIGHT,
+    borderRadius: Buttons.BORDER_RADIUS,
     paddingHorizontal: Paddings.MIN_X,
-    paddingVertical: Paddings.MIN_Y * 3,
-    borderRadius: BORDER_RADIUS,
   },
 });
 

--- a/config/localization/en.json
+++ b/config/localization/en.json
@@ -4,6 +4,7 @@
     "forgotPassword": "Forgot my password",
     "reset": "Reset",
     "signin": "Sign in",
+    "signInGoogle": "Sign in with Google",
     "signup": "Sign up",
     "signout": "Sign out"
   },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -69,6 +69,7 @@ const mapDispatchToProps = (dispatch: Dispatch<Action>) =>
   bindActionCreators(
     {
       signinUser: SigninActions.signinUser,
+      googleOAuthUser: SigninActions.googleOAuthUser,
       clearProgress: () => (d: Dispatch) => d(SigninActions.clearSigninProgress()),
     },
     dispatch
@@ -76,7 +77,14 @@ const mapDispatchToProps = (dispatch: Dispatch<Action>) =>
 
 interface Props extends ReturnType<typeof mapStateToProps>, ReturnType<typeof mapDispatchToProps> {}
 
-function LoginPage({ authDisabled, signinUser, progress, clearProgress, authStatus }: Props) {
+function LoginPage({
+  authDisabled,
+  signinUser,
+  progress,
+  clearProgress,
+  authStatus,
+  googleOAuthUser,
+}: Props) {
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
 
@@ -130,7 +138,7 @@ function LoginPage({ authDisabled, signinUser, progress, clearProgress, authStat
           disabled={submitDisabled}
           onPress={() => signinUser(email, password)}
         />
-        <GoogleButton onPress={loginWithGoogle} />
+        <GoogleButton onPress={googleOAuthUser} />
         <View style={styles.dividerTextContainer}>
           <DividerText label={t('dividers.or').toUpperCase()} />
         </View>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -128,6 +128,7 @@ function LoginPage({ authDisabled, signinUser, progress, clearProgress, authStat
           disabled={submitDisabled}
           onPress={() => signinUser(email, password)}
         />
+        <GoogleButton />
         <View style={styles.dividerTextContainer}>
           <DividerText label={t('dividers.or').toUpperCase()} />
         </View>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -128,7 +128,7 @@ function LoginPage({ authDisabled, signinUser, progress, clearProgress, authStat
           disabled={submitDisabled}
           onPress={() => signinUser(email, password)}
         />
-        <GoogleButton />
+        <GoogleButton onPress={() => console.log('Pressed google button')} />
         <View style={styles.dividerTextContainer}>
           <DividerText label={t('dividers.or').toUpperCase()} />
         </View>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,6 +21,8 @@ import { Colors, Margins, Main, Paddings } from '../styles';
 import FlexLoader from '../components/FlexLoader';
 import DividerText from '../components/DividerText';
 
+import GoogleButton from '../components/SocialButton/GoogleButton';
+
 const logoSource = require('../assets/logo.png');
 
 const styles = StyleSheet.create({

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,6 +21,8 @@ import { Colors, Margins, Main, Paddings } from '../styles';
 import FlexLoader from '../components/FlexLoader';
 import DividerText from '../components/DividerText';
 
+import { loginWithGoogle } from '../api/auth';
+
 import GoogleButton from '../components/SocialButton/GoogleButton';
 
 const logoSource = require('../assets/logo.png');
@@ -128,7 +130,7 @@ function LoginPage({ authDisabled, signinUser, progress, clearProgress, authStat
           disabled={submitDisabled}
           onPress={() => signinUser(email, password)}
         />
-        <GoogleButton onPress={() => console.log('Pressed google button')} />
+        <GoogleButton onPress={loginWithGoogle} />
         <View style={styles.dividerTextContainer}>
           <DividerText label={t('dividers.or').toUpperCase()} />
         </View>

--- a/styles/index.ts
+++ b/styles/index.ts
@@ -45,8 +45,10 @@ export const Shadows = {
 };
 
 export const Buttons = {
-  MIN_WIDTH: 230,
+  BORDER_RADIUS: 5,
   FONT_SIZE: 16,
+  HEIGHT: 48,
+  MIN_WIDTH: 230,
 };
 
 export * from './colors';

--- a/util/svg.js
+++ b/util/svg.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Circle, Path, Rect } from 'react-native-svg';
+import Svg, { Circle, Path, Rect, G } from 'react-native-svg';
 
 export const Website = props => (
   <Svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="#555" {...props}>
@@ -39,5 +39,31 @@ export const Award = props => (
   <Svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="#555" {...props}>
     <Circle cx={12} cy={8} r={7} />
     <Path d="M8.21 13.89L7 23l5-3 5 3-1.21-9.12" />
+  </Svg>
+);
+
+export const GoogleLogo = props => (
+  <Svg width={32} height={32} viewBox="0 0 533.5 544.3" fill="none" stroke="555" {...props}>
+    <G>
+      <Path
+        fill="#4285F4"
+        d="M533.5,278.4c0-18.5-1.5-37.1-4.7-55.3H272.1v104.8h147c-6.1,33.8-25.7,63.7-54.4,82.7v68h87.7
+		C503.9,431.2,533.5,361.2,533.5,278.4z"
+      />
+      <Path
+        fill="#34A853"
+        d="M272.1,544.3c73.4,0,135.3-24.1,180.4-65.7l-87.7-68c-24.4,16.6-55.9,26-92.6,26c-71,0-131.2-47.9-152.8-112.3
+		H28.9v70.1C75.1,486.3,169.2,544.3,272.1,544.3z"
+      />
+      <Path
+        fill="#FBBC04"
+        d="M119.3,324.3c-11.4-33.8-11.4-70.4,0-104.2V150H28.9c-38.6,76.9-38.6,167.5,0,244.4L119.3,324.3z"
+      />
+      <Path
+        fill="#EA4335"
+        d="M272.1,107.7c38.8-0.6,76.3,14,104.4,40.8l0,0l77.7-77.7C405,24.6,339.7-0.8,272.1,0C169.2,0,75.1,58,28.9,150
+		l90.4,70.1C140.8,155.6,201.1,107.7,272.1,107.7z"
+      />
+    </G>
   </Svg>
 );

--- a/util/svg.js
+++ b/util/svg.js
@@ -43,7 +43,7 @@ export const Award = props => (
 );
 
 export const GoogleLogo = props => (
-  <Svg width={32} height={32} viewBox="0 0 533.5 544.3" fill="none" stroke="555" {...props}>
+  <Svg width={18} height={18} viewBox="0 0 533.5 544.3" fill="none" stroke="555" {...props}>
     <G>
       <Path
         fill="#4285F4"


### PR DESCRIPTION
## Summary
This PR addresses an initial ask in #15 by adding in a Google OAuth button, powered by Firebase's Auth SDK, as another login option _just under_ the sign in button. 

Efforts were made to adhere to Google's OAuth button branding, but only around things that provide highest value relative to effort.

## Fix
* Positioning
![form-image](https://user-images.githubusercontent.com/3011292/77717689-7d4b3300-6fb7-11ea-88b2-88d8985f75cf.png)

There's no real reason, other than that this is a pattern seen in other OAuth-powered login widgets.

It will show a Google popup requesting the user to signin via their Google account.

* Google Popup
![popup](https://user-images.githubusercontent.com/3011292/77717784-aec3fe80-6fb7-11ea-810b-0d7c71c25300.png)

Logging in will take the user to the app as expected.

* Using OAuth (Sorry I'm already OAuth'ed and Firebase likely hangs onto the access or oauth token to make this entry seamless, but feel free to pull down the branch and try it yourself!)
![already-oauth](https://user-images.githubusercontent.com/3011292/77717843-d1eeae00-6fb7-11ea-8468-b7ac71f7137f.gif)

Given our redux tooling around signin was dead simple (signin action creators have no payload, they are mostly events, with a caveat for SigninError taking in an error object) meant that passing the errors from Firebase Auth were pretty seamless!

* Closing the popup prematurely
![close-popup](https://user-images.githubusercontent.com/3011292/77718137-7ec92b00-6fb8-11ea-9a6f-b0499fe64b21.gif)

There is some unusualness around what happens if a user signs up via Google OAuth first. It will say the email address is already in use, which _is_ the AuthError for conflicting emails. I haven't done thorough investigation to see what Firebase gives us, to see if we're able to listen for this error and inform the user that they are OAuthed in.

* Already in use
![blocked](https://user-images.githubusercontent.com/3011292/77718457-60176400-6fb9-11ea-968c-57e4dcee0f8d.png)

## Extra Details
Notably, some things are missing or could use improvement in the future, namely:
- clicking the `TouchableOpacity` will affect the child elements (logo and button). Switching this out to an animated variant would likely solve the issue, but given it's a visual want, not a functional want, I moved past to get the feature out ASAP
- Google has guidelines for hover state for their buttons, but given that we at least get the cursor icon, we're not breaking away too much from known UX patterns (but I'll let design/UX decide that)

I was initially concerned about email collision based on some Firebase documentation around AuthErrors. Thankfully, this seems to be a non-issue, presumably Firebase auth also uses emails as a unique identifier, and is able to wire up an existing email user to a new Firebase user. I'm not certain how this will 