### PR TITLE
Add X button on ClusterDetails

### DIFF
--- a/src/components/CoronaMap/ClusterDetails.tsx
+++ b/src/components/CoronaMap/ClusterDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Animated, View, StyleSheet } from 'react-native';
+import { Animated, View, StyleSheet, TouchableOpacity } from 'react-native';
 import { t } from 'i18n-js';
 import Text from '../Text';
 import { Colors, Paddings, Margins } from '../../styles';
@@ -24,6 +24,10 @@ const styles = StyleSheet.create({
     backgroundColor,
     borderRadius: 5,
   },
+  titleLineContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
   lineContainer: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -47,10 +51,11 @@ const styles = StyleSheet.create({
 interface Props {
   cluster: Partial<AnonymListItem<ClusterObject>>;
   duration: number;
+  onClose: () => void;
   style?: any;
 }
 
-function InfoBox({ cluster, duration, style }: Props) {
+function InfoBox({ cluster, duration, onClose, style }: Props) {
   const [persistentCluster, setPersistentCluster] = React.useState(cluster);
 
   React.useEffect(() => {
@@ -75,7 +80,12 @@ function InfoBox({ cluster, duration, style }: Props) {
 
   return (
     <Animated.View style={[styles.container, style]}>
-      <Text style={styles.title}>{t('screens.map.clusterDetailsTitle')}</Text>
+      <View style={styles.titleLineContainer}>
+        <Text style={styles.title}>{t('screens.map.clusterDetailsTitle')}</Text>
+        <TouchableOpacity onPress={onClose}>
+          <Text style={styles.description}>X</Text>
+        </TouchableOpacity>
+      </View>
       {size === 1 ? (
         <Text style={styles.description}>
           {positiveCount === 1

--- a/src/components/CoronaMap/index.tsx
+++ b/src/components/CoronaMap/index.tsx
@@ -108,6 +108,12 @@ function CoronaMap({
     });
   }
 
+  function onClusterDetailsClose() {
+    setClusterDetails(prev => {
+      return { isVisible: false, cluster: {} };
+    })
+  }
+
   if (loadError) {
     return (
       <View style={styles.loadErrorContainer}>
@@ -139,6 +145,7 @@ function CoronaMap({
           isVisible={clusterDetails.isVisible}
           duration={CLUSTER_DETAILS_ANIM_DURATION}
           cluster={clusterDetails.cluster}
+          onClose={onClusterDetailsClose}
           style={[
             styles.clusterDetails,
             {

--- a/src/components/CoronaMap/index.tsx
+++ b/src/components/CoronaMap/index.tsx
@@ -109,9 +109,7 @@ function CoronaMap({
   }
 
   function onClusterDetailsClose() {
-    setClusterDetails(prev => {
-      return { isVisible: false, cluster: {} };
-    })
+    setClusterDetails({ isVisible: false, cluster: {} });
   }
 
   if (loadError) {


### PR DESCRIPTION
Issue: https://github.com/AvenCloud/selftrace/issues/27

Add an "X" button to the top right of `ClusterDetails`. On click, the details box is dismissed.

<img width="485" alt="Screen Shot 2020-04-18 at 3 03 48 PM" src="https://user-images.githubusercontent.com/13670984/79672365-081de880-8186-11ea-9794-88596528e5ac.png">
